### PR TITLE
chore: require release environment approval

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,7 @@ jobs:
     name: Create Tag
     needs: checks
     runs-on: ubuntu-latest
+    environment: production
     permissions:
       contents: write
     outputs:
@@ -245,6 +246,7 @@ jobs:
     needs: [create-tag, build]
     if: failure() && needs.create-tag.result == 'success'
     runs-on: ubuntu-latest
+    environment: production
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
## Summary
- require the protected `production` environment before release tag creation can write repository contents
- require the same protected environment before cleanup can delete the release tag on failure
- leave CI unchanged because it is manual-only (`workflow_dispatch`) and does not run on fork PRs

## Verification
- Parsed workflow YAML locally
- Ran `git diff --check`